### PR TITLE
fix: remove duplicated top-level elements from the runtime index

### DIFF
--- a/src/runtime/index.pug
+++ b/src/runtime/index.pug
@@ -9,9 +9,6 @@ html
     else
       link(rel="stylesheet", href="index.css")
   body
-  html
-  head
-  body
     form#cb-validation(action='javascript:void(0)')
       button#cb-validation-tester(hidden='')
       button#cb-block-enter-key(hidden='')


### PR DESCRIPTION
The runtime index Pug file contained duplicated and semantically invalid entries for the top-level HTML elements `html`, `head`, and `body`.