### PR TITLE
fix: don't collapse whitespace around italicized paragraphs

### DIFF
--- a/src/runtime/template/__tests__/render-parsed.test.ts
+++ b/src/runtime/template/__tests__/render-parsed.test.ts
@@ -194,4 +194,16 @@ describe('renderParsed()', () => {
 				[]
 			).trim()
 		).toBe('<div class="fork"><p>one\ntwo\nthree</p>\n</div>'));
+
+		it("doesn't remove whitespace around italicized paragraphs", () =>
+      expect(
+        renderParsed(
+          {
+            blocks: [{type: 'text', content: '*italic*\n\n*italic*'}],
+            vars: []
+          },
+          [],
+          []
+        ).trim()
+      ).toBe('<p><em>italic</em></p>\n<p><em>italic</em></p>'));
 });

--- a/src/runtime/template/render-parsed.ts
+++ b/src/runtime/template/render-parsed.ts
@@ -195,7 +195,7 @@ export function renderParsed(
 	// Close any whitespace between list items or forks. This can be a side effect
 	// of modifiers running.
 
-	const multipleLinesBetweenItems = /^((>|-|\*).*$)\n{2,}\2/gm;
+	const multipleLinesBetweenItems = /^((>|-|(\*\s)).*$)\n{2,}\2/gm;
 
 	while (multipleLinesBetweenItems.test(markdown)) {
 		markdown = markdown.replace(multipleLinesBetweenItems, '$1\n$2');


### PR DESCRIPTION
Resolves #120 