### PR TITLE
fix: <body-content> scrolls window to top when updating

### DIFF
--- a/demo/tests/lookups.spec.ts
+++ b/demo/tests/lookups.spec.ts
@@ -9,7 +9,7 @@ test('Lookups', async ({page}) => {
 	await expect(content.getByText('browser.height: 720')).toBeVisible();
 	await expect(content.getByText('browser.online: true')).toBeVisible();
 	await expect(content.getByText('browser.width: 1280')).toBeVisible();
-	await expect(content.getByText('engine.version: 2.1.0')).toBeVisible();
+	await expect(content.getByText('engine.version: 2.1.1')).toBeVisible();
 
 	// Skipping date-related lookups.
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   },
   "license": "MIT",
   "type": "module",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "scripts": {
     "build": "node scripts/website.mjs",
     "e2e": "playwright test --config playwright.runtime.config.ts",

--- a/src/runtime/display/custom-elements/__tests__/body-content.test.ts
+++ b/src/runtime/display/custom-elements/__tests__/body-content.test.ts
@@ -59,6 +59,30 @@ describe('<body-content>', () => {
 	});
 
 	describe('when a display-change event is dispatched on window', () => {
+		it('scrolls the window to the top if no disablescroll attribute is set', async () => {
+      const scrollTo = vi.fn();
+
+      vi.stubGlobal('scrollTo', scrollTo);
+      render('<body-content></body-content>');
+      window.dispatchEvent(
+        new CustomEvent('display-change', {detail: {body: 'test'}})
+      );
+      await Promise.resolve();
+      expect(scrollTo.mock.calls).toEqual([[0, 0]]);
+    });
+
+    it("doesn't scroll the window if a disablescroll attribute is set", async () => {
+      const scrollTo = vi.fn();
+
+      vi.stubGlobal('scrollTo', scrollTo);
+      render('<body-content disablescroll></body-content>');
+      window.dispatchEvent(
+        new CustomEvent('display-change', {detail: {body: 'test'}})
+      );
+      await Promise.resolve();
+      expect(scrollTo).not.toBeCalled();
+    });
+
 		it('transitions content with the body transition type and duration', async () => {
 			render('<body-content></body-content>');
 			window.dispatchEvent(

--- a/src/runtime/display/custom-elements/body-content.ts
+++ b/src/runtime/display/custom-elements/body-content.ts
@@ -7,6 +7,9 @@ import {DisplayChangeEventDetail} from '../../custom-events';
 /**
  * Shows the main body content. Available as `<body-content>` and listens for
  * `display-change` events on `window` to perform updates.
+ *
+ * If this has a `disablescroll` attribute, this will not scroll the window when
+ * its content changes as the result of a `display-change` event.
  */
 export class BodyContent extends ContentElement {
 	connectedCallback() {
@@ -38,5 +41,9 @@ export class BodyContent extends ContentElement {
 		this.changeContent(content => {
 			content.innerHTML = detail.body;
 		});
+
+    if (this.getAttribute('disablescroll') === null) {
+      window.scrollTo(0, 0);
+    }
 	}
 }


### PR DESCRIPTION
Can be disabled with disablescroll attribute